### PR TITLE
move hard-coded values to flags

### DIFF
--- a/src/DumpHandler.cpp
+++ b/src/DumpHandler.cpp
@@ -11,7 +11,7 @@
 
 namespace garg { namespace handler {
 
-DumpHandler::DumpHandler(): m_valid(false), m_dumpFile(-1) {}
+DumpHandler::DumpHandler(const std::string& dumpPath): m_valid(false), m_dumpPath(dumpPath), m_dumpFile(-1) {}
 
 void DumpHandler::onRequest(std::unique_ptr<proxygen::HTTPMessage> request) noexcept {
     // POST requests only, and guid query parameter required
@@ -23,7 +23,7 @@ void DumpHandler::onRequest(std::unique_ptr<proxygen::HTTPMessage> request) noex
     }
 
     m_guid = request->getQueryParam("guid");
-    m_dumpFile = folly::openNoInt((std::string("/home/luken/src/Gargamelle/build/crash_reports/") + m_guid + ".gz").data(),
+    m_dumpFile = folly::openNoInt((m_dumpPath + m_guid + ".gz").data(),
             O_CREAT | O_TRUNC | O_RDWR);
     if (m_dumpFile < 0) {
         LOG(ERROR) << "failed to open file to write dump!";
@@ -79,10 +79,11 @@ void DumpHandler::writeFile(folly::EventBase* evb) {
 }
 
 // ==== DumpHandlerFactory
+DumpHandlerFactory::DumpHandlerFactory(const std::string& dumpPath): m_dumpPath(dumpPath) {}
 void DumpHandlerFactory::onServerStart(folly::EventBase*) noexcept {}
 void DumpHandlerFactory::onServerStop() noexcept {}
 proxygen::RequestHandler* DumpHandlerFactory::onRequest(proxygen::RequestHandler*, proxygen::HTTPMessage*) noexcept {
-    return new DumpHandler();
+    return new DumpHandler(m_dumpPath);
 }
 
 } // namespace handler

--- a/src/DumpHandler.hpp
+++ b/src/DumpHandler.hpp
@@ -8,7 +8,7 @@ namespace garg { namespace handler {
 
 class DumpHandler : public proxygen::RequestHandler {
 public:
-    DumpHandler();
+    explicit DumpHandler(const std::string& dumpPath);
 
     void onRequest(std::unique_ptr<proxygen::HTTPMessage> request) noexcept override;
     void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
@@ -20,6 +20,8 @@ public:
 private:
     void writeFile(folly::EventBase* evb);
     bool m_valid;
+    std::string m_dumpPath;
+
     std::string m_guid;
     int m_dumpFile;
     std::unique_ptr<folly::IOBuf> m_body;
@@ -27,9 +29,12 @@ private:
 
 class DumpHandlerFactory : public proxygen::RequestHandlerFactory {
 public:
+    explicit DumpHandlerFactory(const std::string& dumpPath);
     void onServerStart(folly::EventBase*) noexcept override;
     void onServerStop() noexcept override;
     proxygen::RequestHandler* onRequest(proxygen::RequestHandler*, proxygen::HTTPMessage*) noexcept override;
+private:
+    std::string m_dumpPath;
 };
 
 } // namespace handler


### PR DESCRIPTION
should allow for a first test deployment of the crash collection server. Next up is SSL support.